### PR TITLE
Delete CNAME to use new proxy

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-npps.bnl.gov


### PR DESCRIPTION
I think this file needs to go in order to use the new npps.bnl.gov proxy to serve the website.