### PR TITLE
Small changes to illustrate how to reduce clutter in the head directory

### DIFF
--- a/_about/contact.md
+++ b/_about/contact.md
@@ -1,6 +1,8 @@
 ---
 title: Contact us
 layout: default
+abbrev: contact
+weight: 0
 ---
 
 # Contact us

--- a/_about/nppsorg.md
+++ b/_about/nppsorg.md
@@ -1,6 +1,8 @@
 ---
 title: NPPS organization
 layout: default
+abbrev: nppsorg
+weight: 10
 ---
 
 # NPPS organization

--- a/_config.yml
+++ b/_config.yml
@@ -27,3 +27,6 @@ collections:
   people:
     output: true
     permalink: /people/:title.html
+  about:
+    output: true
+    permalink: /about/:title.html

--- a/_data/assets.yml
+++ b/_data/assets.yml
@@ -8,6 +8,15 @@
   date: 2019-03-20
   experiment: atlas eic
 
+- name: https://pos.sissa.it/314/513/
+  title: The protoDUNE-SP experiment and its prompt processing system
+  author: potekhin
+  venue: Proceedings of Science Publication (EPS-HEP2017)
+  type: document
+  format: link
+  date: 2018-03-20
+  experiment: dune
+
 # Slides
 - name: https://docs.google.com/presentation/d/1FEFmbV961EPfKWQrtYvb72LSVNYGia0t7yD3eS9BiC4/edit?usp=sharing
   title: ATLAS Computing in the HL-LHC Era

--- a/_data/assets.yml
+++ b/_data/assets.yml
@@ -71,6 +71,13 @@
   experiment: star
   team: databases
 
+- name: /assets/slides/2020-03-11-potekhin-phenix-dap.pdf
+  title: Data and Analysis Preservation tools for PHENIX
+  author: potekhin
+  venue: PHENIX talk
+  experiment: phenix
+  team: datapreservation
+
 - name: /assets/slides/2019-06-05-viren-dune4npps.pdf
   title: DUNE software overview
   author: viren

--- a/_data/assets.yml
+++ b/_data/assets.yml
@@ -1,3 +1,14 @@
+# Documents
+- name: https://link.springer.com/article/10.1007/s41781-018-0018-8
+  title: A Roadmap for HEP Software and Computing R&D for the 2020s
+  author: wenaus
+  venue: SpringerLink Publication
+  type: document
+  format: link
+  date: 2019-03-20
+  experiment: atlas eic
+
+# Slides
 - name: https://docs.google.com/presentation/d/1FEFmbV961EPfKWQrtYvb72LSVNYGia0t7yD3eS9BiC4/edit?usp=sharing
   title: ATLAS Computing in the HL-LHC Era
   author: wenaus
@@ -75,7 +86,9 @@
   title: Data and Analysis Preservation tools for PHENIX
   author: potekhin
   venue: PHENIX talk
+  date: 2020-03-11
   experiment: phenix
+  software: jekyll zenodo
   team: datapreservation
 
 - name: /assets/slides/2019-06-05-viren-dune4npps.pdf

--- a/_experiments/eic.md
+++ b/_experiments/eic.md
@@ -10,8 +10,9 @@ layout: default
 {% include experimentspecs.html %}
 
 ### References
-
-   - [EIC Users Group](http://www.eicug.org)
-   - [BNL EIC wiki](https://wiki.bnl.gov/eic/index.php/Main_Page)
+   - [Official EIC site at BNL](https://www.bnl.gov/eic/)
+   - [Main EIC User Group Wiki](https://wiki.bnl.gov/eicug/index.php/Main_Page)
+   - [EIC User Group Website](http://www.eicug.org)
+   - [EIC BNL Group Wiki](https://wiki.bnl.gov/eic/index.php/Main_Page)
 
    

--- a/_experiments/phenix.md
+++ b/_experiments/phenix.md
@@ -2,7 +2,7 @@
 title: PHENIX at RHIC (BNL)
 abbrev: PHENIX
 experiment: phenix
-software: fun4all rootframework invenio jekyll
+software: fun4all rootframework invenio jekyll zenodo
 teams: simulation datapreservation
 layout: default
 ---

--- a/_includes/navbar.ext
+++ b/_includes/navbar.ext
@@ -58,10 +58,11 @@
                   <li><a href="https://calendar.google.com/calendar/embed?src=e4v33e1a1drbncdle1n03ahpcs%40group.calendar.google.com&ctz=Europe/Amsterdam"  target="_blank">HSF community calendar</a></li>
                 </ul>
             </li>
- 
+
+	    <!-- RESOURCES -->
              <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="/projects.html" id="projects_menu">Resources<span class="caret"></span></a>
-                <ul class="dropdown-menu" aria-labelledby="projects_menu">
+              <ul class="dropdown-menu" aria-labelledby="projects_menu">
                   <li><a href="/who.html">People</a></li>
                   <li><a href="/documents.html">Documents &amp; Presentations</a></li>
                   <li><a href="/support.html">Support and operations</a></li>
@@ -70,12 +71,17 @@
             </li>
 
           </ul>
+
+
           <ul class="nav navbar-nav navbar-right">
+	  <!-- ABOUT -->
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="/index.html" id="about_menu">About<span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="about_menu">
-                <li><a href="/contact.html">Contact us</a></li>
-                <li><a href="/nppsorg.html">NPPS organization</a><li>
+		 {% assign items = site.about | sort: 'weight' %}
+                 {% for item in items %}
+                   <li><a href="{{ item.url | relative_url }}">{{ item.title }}</a></li>
+                 {% endfor %}
                 <li><a href="/who.html">Who we are</a></li>
                 <li><a href="/howto-website.html">Website info and howto</a></li>
                 
@@ -83,7 +89,6 @@
                 <li><a href="https://www.bnl.gov/physics/" target="_blank">Physics at BNL</a></li>
                 <li><a href="https://www.sdcc.bnl.gov/" target="_blank">Scientific computing at BNL</a></li>
                 <li><a href="https://hepsoftwarefoundation.org" target="_blank">Community software</a></li>
-
               </ul>
             </li>
           </ul>

--- a/_includes/persondetails.html
+++ b/_includes/persondetails.html
@@ -1,4 +1,5 @@
-<a href="{{ who.url }}" role="button">{{ who.title }}</a>
+<!-- a href="{{ who.url }}" role="button">{{ who.title }}</a -->
+<a href="{{ who.url }}" >{{ who.title }}</a>
 
   {% if who.tags contains 'grouplead' %}
     &nbsp; &nbsp; NPPS group leader

--- a/_includes/softwarespecs.html
+++ b/_includes/softwarespecs.html
@@ -21,7 +21,7 @@
 
 <p>
 {% if page.ref.size > 0 %}
-    <a href="{{page.ref}}">Website</a>
+    <a href="{{ page.ref }}">Website</a>
 {% endif %}
 </p>
 

--- a/_people/potekhin.md
+++ b/_people/potekhin.md
@@ -5,7 +5,7 @@ experiments: phenix eic dune
 teams: collabtools simulation datapreservation databases
 software: dunedqm invenio jekyll zenodo
 tags: member appointments
-appointments: PHENIX Simulation Convener
+appointments: PHENIX Simulation Convener, PHENIX DAP Task Force member
 layout: default
 ---
 

--- a/_people/potekhin.md
+++ b/_people/potekhin.md
@@ -3,7 +3,7 @@ title: Maxim Potekhin
 name: potekhin
 experiments: phenix eic dune
 teams: collabtools simulation datapreservation databases
-software: dunedqm invenio jekyll
+software: dunedqm invenio jekyll zenodo
 tags: member appointments
 appointments: PHENIX Simulation Convener
 layout: default

--- a/_software/zenodo.md
+++ b/_software/zenodo.md
@@ -1,0 +1,11 @@
+---
+title: Zenodo
+software: zenodo
+synopsis: Digital Repository developed and deployed at CERN
+teams: datapreservation
+common: true
+ref: https://zenodo.org
+layout: default
+---
+
+{% include softwarespecs.html %}

--- a/documents.md
+++ b/documents.md
@@ -12,21 +12,27 @@ Documents and presentations with NPPS (co)authorship
 <ul>
 {% for item in site.data.assets reversed %}
   {% if item.type == 'document' or item.name contains "/assets/documents" %}
-
     {% if item.date %}
-        {% assign date = item.date | string_to_date | date: "%Y-%m-%d" %}
+        {% assign itemdate = item.date | string_to_date | date: "%Y-%m-%d" %}
     {% else %}
-        {% assign date = item.name | remove: "/assets/documents/" | string_to_date | date: "%Y-%m-%d" %}
+        {% assign itemdate = item.name | remove: "/assets/documents/" | string_to_date | date: "%Y-%m-%d" %}
     {% endif %}
 
-    <li><a href="{{item.name}}" target="_blank">{{item.title}}</a>
+    <li><a href="{{item.name}}" target="_blank">{{item.title}}</a>, &nbsp;
     
     <!-- horrible, but liquid has no named element arrays or dicts -->
     {% for person in site.data.people %}
-      {% if person.name == item.author %}
-        <br> <a href="/people/{{person.name}}">{{ person.full }}</a>, {{ item.date | date: "%b %Y" }}
+    <!-- mxp: I disabled the author field for now since there are multiple and will design later -->
+      {% if person.name == item.author and false %}
+        <a href="/people/{{person.name}}">{{ person.full }}</a>, {{ item.date | date: "%b %Y" }}
       {% endif %}
     {% endfor %}
+  {% if item.venue.size > 0 %}
+    {{ item.venue }},
+  {% endif %}
+
+    &nbsp; {{ itemdate | date: "%b %Y" }}
+    
     </li>
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
Migrated two source files to a new subfolder named "_about" which reflects the name of the navigation menu item. This lessens clutter in the head directory. If this is OK, I can move all items in the "about" category and gradually do the same for the rest of the navigation bar. This way the head directory will be neat and readable, and source material easier to locate.